### PR TITLE
tech(db): adds a where helper for stores

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,24 +26,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  name = "github.com/gorilla/context"
-  packages = ["."]
-  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
-  version = "v1.1"
-
-[[projects]]
-  name = "github.com/gorilla/securecookie"
-  packages = ["."]
-  revision = "e59506cc896acb7f7bf732d4fdf5e25f7ccd8983"
-  version = "v1.1.1"
-
-[[projects]]
-  name = "github.com/gorilla/sessions"
-  packages = ["."]
-  revision = "ca9ada44574153444b00d3fd9c8559e4cc95f896"
-  version = "v1.1"
-
-[[projects]]
   branch = "master"
   name = "github.com/jmoiron/sqlx"
   packages = [".","reflectx"]
@@ -148,6 +130,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "129f91f8d866ae3f7ada3d09d9206cb6e86eb1e0a81b8572c9d3fed3e035cc49"
+  inputs-digest = "b421fb41b92536fb8fd6e847b576236d52b2c50acfb237cf4af386688e92a191"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/stores/helpers.go
+++ b/stores/helpers.go
@@ -1,0 +1,35 @@
+package stores
+
+// QueryModifierOp is a enum type to indicate the modifer operation
+type QueryModifierOp = string
+
+const (
+	EQ  = "="
+	LT  = "<"
+	LTE = "<="
+	NE  = "!="
+	GT  = ">"
+	GTE = ">="
+)
+
+var (
+	// And is a query modifier
+	And = QueryModifier{"AND", EQ, nil}
+	// Or is a query modifier
+	Or = QueryModifier{"OR", EQ, nil}
+)
+
+// QueryModifier is used in where queries to add selection criteria
+type QueryModifier struct {
+	Column   string
+	Operator QueryModifierOp
+	Value    interface{}
+}
+
+func QueryMod(col string, operator QueryModifierOp, value interface{}) QueryModifier {
+	return QueryModifier{
+		Column:   col,
+		Operator: operator,
+		Value:    value,
+	}
+}

--- a/stores/postgres/helpers.go
+++ b/stores/postgres/helpers.go
@@ -1,0 +1,30 @@
+package postgres
+
+import (
+	"strconv"
+
+	"github.com/ucladevx/BPool/stores"
+)
+
+func generateWhereStatement(modifiers *[]stores.QueryModifier) (string, []interface{}) {
+	var args []interface{}
+	where := "WHERE "
+
+	count := 1
+	for _, modifier := range *modifiers {
+		if modifier.Column == "AND" || modifier.Column == "OR" {
+			where += modifier.Column + " "
+			continue
+		}
+
+		if modifier.Column == "" || modifier.Value == nil {
+			return "", nil
+		}
+
+		where += modifier.Column + modifier.Operator + "$" + strconv.Itoa(count) + " "
+		args = append(args, modifier.Value)
+		count++
+	}
+
+	return where, args
+}

--- a/stores/postgres/helpers_test.go
+++ b/stores/postgres/helpers_test.go
@@ -1,0 +1,79 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/ucladevx/BPool/stores"
+)
+
+func TestGenerateWhereStatement(t *testing.T) {
+	tables := []struct {
+		name         string
+		args         []stores.QueryModifier
+		resultQuery  string
+		resultValues []interface{}
+	}{
+		{"single arg", []stores.QueryModifier{stores.QueryMod("id", stores.EQ, "123")}, "WHERE id=$1 ", []interface{}{"123"}},
+		{"two args with AND", []stores.QueryModifier{stores.QueryMod("id", stores.EQ, 123), stores.And, stores.QueryMod("val", stores.NE, "abc")}, "WHERE id=$1 AND val!=$2 ", []interface{}{123, "abc"}},
+		{"bad args", []stores.QueryModifier{stores.QueryMod("", stores.EQ, "")}, "", nil},
+		{"tests floats", []stores.QueryModifier{stores.QueryMod("id", stores.EQ, 1.0)}, "WHERE id=$1 ", []interface{}{1.0}},
+		{"tests bools", []stores.QueryModifier{stores.QueryMod("admin", stores.EQ, true)}, "WHERE admin=$1 ", []interface{}{true}},
+	}
+
+	for _, tt := range tables {
+		tt := tt
+
+		query, vals := generateWhereStatement(&tt.args)
+		if query != tt.resultQuery {
+			t.Errorf("%s should have query of %s, but is %s", tt.name, tt.resultQuery, query)
+		}
+		if len(vals) != len(tt.resultValues) {
+			t.Errorf("%s should have %d vals, but has %d", tt.name, len(tt.resultValues), len(vals))
+		}
+
+		for i, val := range vals {
+			switch v := val.(type) {
+			case int:
+				o, ok := tt.resultValues[i].(int)
+				if !ok {
+					t.Errorf("%s should have been an %t, but was an int", tt.name, tt.resultValues[i])
+				}
+
+				if v != o {
+					t.Errorf("%s should have been an %v, but was %v", tt.name, o, v)
+				}
+				continue
+			case string:
+				o, ok := tt.resultValues[i].(string)
+				if !ok {
+					t.Errorf("%s should have been an %t, but was an string", tt.name, tt.resultValues[i])
+				}
+
+				if v != o {
+					t.Errorf("%s should have been an %v, but was %v", tt.name, o, v)
+				}
+				continue
+			case float64:
+				o, ok := tt.resultValues[i].(float64)
+				if !ok {
+					t.Errorf("%s should have been an %t, but was an float64", tt.name, tt.resultValues[i])
+				}
+
+				if v != o {
+					t.Errorf("%s should have been an %v, but was %v", tt.name, o, v)
+				}
+				continue
+			case bool:
+				o, ok := tt.resultValues[i].(bool)
+				if !ok {
+					t.Errorf("%s should have been an %t, but was an bool", tt.name, tt.resultValues[i])
+				}
+
+				if v != o {
+					t.Errorf("%s should have been an %v, but was %v", tt.name, o, v)
+				}
+				continue
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Description
Allows for easier querying without having to create custom functions.  Adds a abstracted way of doing this for any DB, and a specific implementation in postgres.

# Steps to Reproduce
Example usage

```go
generateWhereStatement(
    stores.QueryMod("id", stores.EQ, "adsfasdf"),
    stores.And,
    stores.QueryMod("auth_level", stores.NE, "user"),
)
```

# Tested
Full unit tests were added with 100% coverage

# Approved
- [x] Luke
- [x] Jahan